### PR TITLE
gemspec: loosen faraday specification to ~> 0.9

### DIFF
--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Restforce::VERSION
 
-  gem.add_dependency 'faraday', '~> 0.9.0'
+  gem.add_dependency 'faraday', '~> 0.9'
   gem.add_dependency 'faraday_middleware', '>= 0.8.8'
   gem.add_dependency 'json', ['>= 1.7.5', '< 1.9.0']
   gem.add_dependency 'hashie', ['>= 1.2.0', '< 4.0']


### PR DESCRIPTION
permit faraday `~> 0.9` instead of `~> 0.9.0` to address Bundler
dependency resolution issues